### PR TITLE
storage: add support for drive type/proto

### DIFF
--- a/src/storage/inventory.hpp
+++ b/src/storage/inventory.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <xyz/openbmc_project/Inventory/Decorator/Asset/server.hpp>
+#include <xyz/openbmc_project/Inventory/Decorator/Connection/server.hpp>
 #include <xyz/openbmc_project/Inventory/Item/Drive/server.hpp>
 #include <xyz/openbmc_project/Inventory/Item/server.hpp>
 #include <xyz/openbmc_project/State/Decorator/OperationalStatus/server.hpp>
@@ -17,12 +18,16 @@ class StorageDrive :
         sdbusplus::xyz::openbmc_project::Inventory::Item::server::Drive>,
     sdbusplus::server::object::object<
         sdbusplus::xyz::openbmc_project::Inventory::Decorator::server::Asset>,
+    sdbusplus::server::object::object<
+        sdbusplus::xyz::openbmc_project::Inventory::Decorator::server::
+            Connection>,
     sdbusplus::server::object::object<sdbusplus::xyz::openbmc_project::State::
                                           Decorator::server::OperationalStatus>
 {
   public:
     StorageDrive(sdbusplus::bus::bus& bus, const std::string& aName,
-                 const std::string& aPath, const std::string& aType,
-                 const std::string& aVendor, const std::string& aModel,
-                 const std::string& aSerial, const std::string& aSizeBytes);
+                 const std::string& aPath, const std::string& aProto,
+                 const std::string& aType, const std::string& aVendor,
+                 const std::string& aModel, const std::string& aSerial,
+                 const std::string& aSizeBytes);
 };

--- a/src/storage/main.cpp
+++ b/src/storage/main.cpp
@@ -38,6 +38,7 @@ class Manager : StorageManagerServer
 enum Fields
 {
     path = 0,
+    proto,
     type,
     vendor,
     model,
@@ -79,8 +80,8 @@ void Manager::rescan()
         }
         drives.emplace_back(std::make_shared<StorageDrive>(
             bus, "drive " + std::to_string(index), entryFields[path],
-            entryFields[type], entryFields[vendor], entryFields[model],
-            entryFields[serial], entryFields[sizeBytes]));
+            entryFields[proto], entryFields[type], entryFields[vendor],
+            entryFields[model], entryFields[serial], entryFields[sizeBytes]));
         index++;
     }
 }


### PR DESCRIPTION
Handle drive media type (HDD/SSD) and protocol (SATA/SAS/NVMe).
Fix issues in PrettyName generation.
Fix dbus object path for drive.

Signed-off-by: Andrei Kartashev <a.kartashev@yadro.com>