### PR TITLE
update drive protocol interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,18 +34,18 @@ Storage manager aimed to provide inventory information about storage devices and
   └─/xyz/openbmc_project
     └─/xyz/openbmc_project/inventory
       └─/xyz/openbmc_project/inventory/system
-        └─/xyz/openbmc_project/inventory/system/chassis
-          ├─/xyz/openbmc_project/inventory/system/chassis/drive_1
-          ├─/xyz/openbmc_project/inventory/system/chassis/drive_2
+        └─/xyz/openbmc_project/inventory/system/drive
+          ├─/xyz/openbmc_project/inventory/system/drive/drive_1
+          ├─/xyz/openbmc_project/inventory/system/drive/drive_2
 ```
-Each drive object contains folowing interfaces:
+Each drive object contains following interfaces:
 * xyz.openbmc_project.Inventory.Item
 * xyz.openbmc_project.Inventory.Item.Drive
 * xyz.openbmc_project.Inventory.Decorator.Asset
 * xyz.openbmc_project.State.Decorator.OperationalStatus
 
 ```
-# busctl introspect com.yadro.Storage /xyz/openbmc_project/inventory/system/chassis/drive_1
+~# busctl introspect com.yadro.Storage /xyz/openbmc_project/inventory/system/drive/drive_1
 NAME                                                  TYPE      SIGNATURE RESULT/VALUE                             FLAGS
 org.freedesktop.DBus.Introspectable                   interface -         -                                        -
 .Introspect                                           method    -         s                                        -
@@ -68,6 +68,7 @@ xyz.openbmc_project.Inventory.Item                    interface -         -     
 .PrettyName                                           property  s         "SATA 250GB drive 1"                     emits-change writable
 xyz.openbmc_project.Inventory.Item.Drive              interface -         -                                        -
 .Capacity                                             property  t         250059350016                             emits-change writable
+.Interfaces                                           property  as        1 "xyz.openbmc_project.Inventory.Item.D… emits-change writable
 .Type                                                 property  s         "xyz.openbmc_project.Inventory.Item.Dri… emits-change writable
 xyz.openbmc_project.State.Decorator.OperationalStatus interface -         -                                        -
 .Functional                                           property  b         true                                     emits-change writable

--- a/src/storage/inventory.cpp
+++ b/src/storage/inventory.cpp
@@ -69,11 +69,6 @@ StorageDrive::StorageDrive(sdbusplus::bus::bus& bus, const std::string& aName,
         bus, dbusEscape(std::string(dbus::inventory::pathBase) +
                         inventorySubPath + aName)
                  .c_str()),
-    sdbusplus::server::object::object<
-        sdbusplus::xyz::openbmc_project::Inventory::Decorator::server::
-            Connection>(bus, dbusEscape(std::string(dbus::inventory::pathBase) +
-                                        inventorySubPath + aName)
-                                 .c_str()),
     sdbusplus::server::object::object<sdbusplus::xyz::openbmc_project::State::
                                           Decorator::server::OperationalStatus>(
         bus, dbusEscape(std::string(dbus::inventory::pathBase) +
@@ -153,27 +148,27 @@ StorageDrive::StorageDrive(sdbusplus::bus::bus& bus, const std::string& aName,
     }
     name += aName;
 
-    Connection::ProtoType proto = Connection::ProtoType::Unknown;
+    std::vector<DriveInterface> iface;
     if (aProto == "SATA")
     {
-        proto = Connection::ProtoType::SATA;
+        iface.emplace_back(DriveInterface::SATA);
     }
     else if (aProto == "SAS")
     {
-        proto = Connection::ProtoType::SAS;
+        iface.emplace_back(DriveInterface::SAS);
     }
     else if (aProto == "NVMe")
     {
-        proto = Connection::ProtoType::NVMe;
+        iface.emplace_back(DriveInterface::NVMe);
     }
-    Drive::DriveType driveType = Drive::DriveType::Unknown;
+    DriveType driveType = DriveType::Unknown;
     if (aType == "SSD")
     {
-        driveType = Drive::DriveType::SSD;
+        driveType = DriveType::SSD;
     }
     else if (aType == "HDD")
     {
-        driveType = Drive::DriveType::HDD;
+        driveType = DriveType::HDD;
     }
 
     // xyz.openbmc_project.Inventory.Item
@@ -182,12 +177,11 @@ StorageDrive::StorageDrive(sdbusplus::bus::bus& bus, const std::string& aName,
     // xyz.openbmc_project.Inventory.Item.Drive
     capacity(sizeInt);
     type(driveType);
+    interfaces(iface);
     // xyz.openbmc_project.Inventory.Decorator.Asset
     serialNumber(aSerial);
     manufacturer(manuf);
     model(aModel);
-    // xyz.openbmc_project.Inventory.Decorator.Connection
-    protocol(proto);
     // xyz.openbmc_project.State.Decorator.OperationalStatus
     functional(true);
 }

--- a/src/storage/inventory.hpp
+++ b/src/storage/inventory.hpp
@@ -6,7 +6,6 @@
 #pragma once
 
 #include <xyz/openbmc_project/Inventory/Decorator/Asset/server.hpp>
-#include <xyz/openbmc_project/Inventory/Decorator/Connection/server.hpp>
 #include <xyz/openbmc_project/Inventory/Item/Drive/server.hpp>
 #include <xyz/openbmc_project/Inventory/Item/server.hpp>
 #include <xyz/openbmc_project/State/Decorator/OperationalStatus/server.hpp>
@@ -18,9 +17,6 @@ class StorageDrive :
         sdbusplus::xyz::openbmc_project::Inventory::Item::server::Drive>,
     sdbusplus::server::object::object<
         sdbusplus::xyz::openbmc_project::Inventory::Decorator::server::Asset>,
-    sdbusplus::server::object::object<
-        sdbusplus::xyz::openbmc_project::Inventory::Decorator::server::
-            Connection>,
     sdbusplus::server::object::object<sdbusplus::xyz::openbmc_project::State::
                                           Decorator::server::OperationalStatus>
 {

--- a/src/storage/main.cpp
+++ b/src/storage/main.cpp
@@ -94,7 +94,7 @@ void Manager::rescan()
 int main()
 {
     auto bus = sdbusplus::bus::new_default();
-    sdbusplus::server::manager_t objManager(bus, dbus::stormgr::path);
+    sdbusplus::server::manager_t objManager(bus, "/");
 
     bus.request_name(dbus::stormgr::busName);
     Manager storageManager(bus);


### PR DESCRIPTION
It was decided to place protocol to Item.Drive interface.
See https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-dbus-interfaces/+/46333

Signed-off-by: Andrei Kartashev <a.kartashev@yadro.com>