### PR TITLE
hw_mngr: fix HWManagerData initialization

### DIFF
--- a/src/hw/hw_mngr.hpp
+++ b/src/hw/hw_mngr.hpp
@@ -36,7 +36,9 @@ struct HWManagerData
     std::map<size_t, bool> cpuPresence;
     std::map<std::string, ChassisPIDZone> chassisFans;
 
-    HWManagerData() : haveCPUFans(false)
+    HWManagerData() :
+        desc(nullptr), chassisModel(), chassisPartNumber(), chassisSerial(),
+        haveCPUFans(false), cpuPresence(), chassisFans()
     {}
     void reset()
     {


### PR DESCRIPTION
The HWManagerData constructor doesn't initialize own struct properties.
That leads to a segmetation fault on some case there was `desc` refer to
the non-nullptr.

End-user-impact: None.

Signed-off-by: Igor Kononenko <i.kononenko@yadro.com>