### PR TITLE
hw-manager: allow to limit mex FAN speed

### DIFF
--- a/com/yadro/HWManager/Fan.interface.yaml
+++ b/com/yadro/HWManager/Fan.interface.yaml
@@ -45,3 +45,10 @@ properties:
         - readonly
       description: >
           Index of Fan PWM line
+    - name: pwm_limit_max
+      type: uint32
+      default: 100
+      flags:
+        - readonly
+      description: >
+          Upper speed limit for Fan PWM, 30..100%

--- a/src/hw/hw_mngr.cpp
+++ b/src/hw/hw_mngr.cpp
@@ -154,7 +154,8 @@ void HWManager::publish()
             fans.emplace_back(std::make_shared<Fan>(
                 bus, "Sys_Fan" + fanIndexStr, "System Fan " + fanIndexStr,
                 sysFanMod, sysFanPN, conDescr.zone, conDescr.connector,
-                conDescr.tachIndexA, conDescr.tachIndexB, conDescr.pwmIndex));
+                conDescr.tachIndexA, conDescr.tachIndexB, conDescr.pwmIndex,
+                conDescr.pwmLimitMax));
         }
         else if ((conDescr.type == ConnectorType::CPU) && config.haveCPUFans)
         {
@@ -166,7 +167,8 @@ void HWManager::publish()
                     bus, "CPU" + fanIndexStr + "_Fan",
                     "CPU" + fanIndexStr + " Fan", cpuFanMod, cpuFanPN,
                     conDescr.zone, conDescr.connector, conDescr.tachIndexA,
-                    conDescr.tachIndexB, conDescr.pwmIndex));
+                    conDescr.tachIndexB, conDescr.pwmIndex,
+                    conDescr.pwmLimitMax));
             }
         }
     }
@@ -202,7 +204,7 @@ void HWManager::publish()
                 bus, "Cha_Fan" + fanIndexStr, "Chassis Fan " + fanIndexStr,
                 chsFanMod, chsFanPN, zoneName, it->second.connector,
                 it->second.tachIndexA, it->second.tachIndexB,
-                it->second.pwmIndex));
+                it->second.pwmIndex, it->second.pwmLimitMax));
             chassisFanIndex++;
         }
     }

--- a/src/hw/objects.cpp
+++ b/src/hw/objects.cpp
@@ -24,7 +24,8 @@ Fan::Fan(sdbusplus::bus::bus& bus, const std::string& aName,
          const std::string& aPrettyName, const std::string& aModel,
          const std::string& aPartNumber, const std::string& aZone,
          const std::string& aConnector, const uint32_t& aTachIndexA,
-         const uint32_t& aTachIndexB, const uint32_t& aPwmIndex) :
+         const uint32_t& aTachIndexB, const uint32_t& aPwmIndex,
+         const uint32_t& aPwmLimitMax) :
     HWManagerFanServer(
         bus,
         dbusEscape(std::string(dbus::hwmgr::path) + "/fan/" + aName).c_str())
@@ -45,4 +46,8 @@ Fan::Fan(sdbusplus::bus::bus& bus, const std::string& aName,
     // object created early then Chassis object. There is "FOUND" Match
     // condition that should help to fight the race but it doesn't work.
     pwmIndex(aPwmIndex);
+    if (aPwmLimitMax >= 30 && aPwmLimitMax <= 100)
+    {
+        pwmLimitMax(aPwmLimitMax);
+    }
 }

--- a/src/hw/objects.hpp
+++ b/src/hw/objects.hpp
@@ -27,5 +27,6 @@ class Fan : HWManagerFanServer
         const std::string& aPrettyName, const std::string& aModel,
         const std::string& aPartNumber, const std::string& aZone,
         const std::string& aConnector, const uint32_t& aTachIndexA,
-        const uint32_t& aTachIndexB, const uint32_t& aPwmIndex);
+        const uint32_t& aTachIndexB, const uint32_t& aPwmIndex,
+        const uint32_t& aPwmLimitMax);
 };

--- a/src/hw/product_registry.hpp
+++ b/src/hw/product_registry.hpp
@@ -23,6 +23,7 @@ struct FanConDescription
     uint32_t tachIndexA;
     uint32_t tachIndexB;
     uint32_t pwmIndex;
+    uint32_t pwmLimitMax;
 };
 
 static const std::map<size_t, FanConDescription> FanConnectorsN110 = {
@@ -196,7 +197,8 @@ static const std::map<size_t, FanConDescription> FanConnectorsR120 = {
       .zone = "Main",
       .tachIndexA = 1,
       .tachIndexB = 8,
-      .pwmIndex = 1}},
+      .pwmIndex = 1,
+      .pwmLimitMax = 80}},
     {2,
      {.type = ConnectorType::SYSTEM,
       .fanIndex = 2,
@@ -212,7 +214,8 @@ static const std::map<size_t, FanConDescription> FanConnectorsR120 = {
       .zone = "Main",
       .tachIndexA = 0,
       .tachIndexB = 7,
-      .pwmIndex = 0}},
+      .pwmIndex = 0,
+      .pwmLimitMax = 80}},
     {4,
      {.type = ConnectorType::SYSTEM,
       .fanIndex = 4,
@@ -220,7 +223,8 @@ static const std::map<size_t, FanConDescription> FanConnectorsR120 = {
       .zone = "Main",
       .tachIndexA = 4,
       .tachIndexB = 11,
-      .pwmIndex = 4}},
+      .pwmIndex = 4,
+      .pwmLimitMax = 80}},
     {5,
      {.type = ConnectorType::SYSTEM,
       .fanIndex = 5,
@@ -244,7 +248,8 @@ static const std::map<size_t, FanConDescription> FanConnectorsR120 = {
       .zone = "Main",
       .tachIndexA = 6,
       .tachIndexB = 13,
-      .pwmIndex = 6}},
+      .pwmIndex = 6,
+      .pwmLimitMax = 86}},
 };
 static const std::map<size_t, FanConDescription> FanConnectorsR220 = {
     {1,


### PR DESCRIPTION
It was found on VEGMAN R120 that for maximum cooling performance, not
all fans should work on highest speed: some fan should give less airflow
to not disturb flow from other fans.

This commis brings ability to set upper speed limit for particular fan.

Signed-off-by: Andrei Kartashev <a.kartashev@yadro.com>