### PR TITLE
storage: fix refresh condition

### DIFF
--- a/src/storage/backplane_control.cpp
+++ b/src/storage/backplane_control.cpp
@@ -264,7 +264,7 @@ bool BackplaneController::doRefresh()
 
         std::vector<std::tuple<std::string, std::string, DriveInterface, bool>>
             drivesState;
-        if (mcu->ifStateChanged(cachedState) && (!drives().empty()))
+        if (!(mcu->isStateChanged(cachedState) || drives().empty()))
         {
             return true;
         }

--- a/src/storage/backplane_mcu_driver.hpp
+++ b/src/storage/backplane_mcu_driver.hpp
@@ -51,7 +51,7 @@ class BackplaneMCUDriver
     virtual bool getDriveLocationLED(int chanIndex) = 0;
     virtual void resetDriveLocationLEDs() = 0;
     virtual void setHostPowerState(bool powered) = 0;
-    virtual bool ifStateChanged(uint32_t& cache) = 0;
+    virtual bool isStateChanged(uint32_t& cache) = 0;
 
     static constexpr int maxChannelsNumber = 8;
 
@@ -75,7 +75,7 @@ class MCUProtoV0 : public BackplaneMCUDriver
     bool getDriveLocationLED(int chanIndex);
     void resetDriveLocationLEDs();
     void setHostPowerState(bool powered);
-    bool ifStateChanged(uint32_t& cache);
+    bool isStateChanged(uint32_t& cache);
 
   private:
     void getDrivesPresence();
@@ -101,7 +101,7 @@ class MCUProtoV1 : public BackplaneMCUDriver
     bool getDriveLocationLED(int chanIndex);
     void resetDriveLocationLEDs();
     void setHostPowerState(bool powered);
-    bool ifStateChanged(uint32_t& cache);
+    bool isStateChanged(uint32_t& cache);
 
   private:
     void getDrivesPresence();

--- a/src/storage/backplane_mcu_driver_v0.cpp
+++ b/src/storage/backplane_mcu_driver_v0.cpp
@@ -175,13 +175,13 @@ void MCUProtoV0::setHostPowerState(bool powered)
     }
 }
 
-bool MCUProtoV0::ifStateChanged(uint32_t& cache)
+bool MCUProtoV0::isStateChanged(uint32_t& cache)
 {
     bool res;
     getDrivesPresence();
     getDrivesFailures();
     uint32_t newState = dPresence | (dFailures >> 8);
-    res = newState == cache;
+    res = (newState != cache);
     cache = newState;
     return res;
 }

--- a/src/storage/backplane_mcu_driver_v1.cpp
+++ b/src/storage/backplane_mcu_driver_v1.cpp
@@ -177,14 +177,18 @@ void MCUProtoV1::setHostPowerState(bool powered)
     }
 }
 
-bool MCUProtoV1::ifStateChanged(uint32_t& cache)
+bool MCUProtoV1::isStateChanged(uint32_t& cache)
 {
     bool ret;
     getDrivesPresence();
     getDrivesFailures();
     uint32_t newState = dPresence | (dFailures >> 8);
-    ret = newState == cache;
+    ret = (newState != cache);
     cache = newState;
+    if (ret)
+    {
+        return true;
+    }
 
     int res = dev->read_byte_data(OPC_GET_DISC_SWAP);
     if (res < 0)


### PR DESCRIPTION
The state check function was initially called `ifStateChanged` which is
meanless and actually should be `is...`, but basic implementation was
vise versa (`isNot...`). This caused follow up mistakes in the method
implementation and usage.

This commit fixes the issue.

Signed-off-by: Andrei Kartashev <a.kartashev@yadro.com>