### PR TITLE
hw-mgr: Log the applying of min PWM restriction

### DIFF
--- a/src/hw/hw_mngr.cpp
+++ b/src/hw/hw_mngr.cpp
@@ -525,6 +525,14 @@ void HWManager::setFanSpeed()
             continue;
         }
 
+        sd_journal_send(
+            "MESSAGE=%s", "Fan PWM minimum changed due to hardware policy",
+            "PRIORITY=%i", LOG_INFO, "ZONE_NAME=%s", zoneName.c_str(),
+            "CUR_VALUE=%0.0f", curValue, "NEW_VALUE=%0.0f", fanMinSpeed,
+            "REDFISH_MESSAGE_ID=%s", "OpenBMC.0.1.FanMinPwmRestricted",
+            "REDFISH_MESSAGE_ARGS=%s,%0.0f,%0.0f", zoneName.c_str(), curValue,
+            fanMinSpeed, NULL);
+
         data = fanMinSpeed;
         auto setProperty = bus.new_method_call(owner.c_str(), path.c_str(),
                                                dbus::properties::interface,


### PR DESCRIPTION
This adds a sending of the event-log message on applying the Fan minimal PWM value from EEPROM (aka hardware policy).

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>