### PR TITLE
Disable spam log in yadro-storage-manager service

### DIFF
--- a/src/common_i2c.cpp
+++ b/src/common_i2c.cpp
@@ -21,6 +21,10 @@
 using namespace phosphor::logging;
 static constexpr int retryCount = 3;
 
+//  false - reduces multiple errors and disables debug messages
+//  true - allows multiple errors and debug messages
+bool i2cDev::verbose = false;
+
 //  each i2cDev object can be recreated; but we need permanent context
 struct I2cContext
 {
@@ -340,7 +344,7 @@ void i2cDev::logTransfer(int cmd, const void* txData, size_t txDataLen,
                          const void* rxData, size_t rxDataLen, int res)
 {
     //  stop spaming to log on multiple errors
-    if (isSpamingToLog(*this, res))
+    if (!i2cDev::verbose && isSpamingToLog(*this, res))
     {
         return;
     }
@@ -383,11 +387,11 @@ void i2cDev::logTransfer(int cmd, const void* txData, size_t txDataLen,
         }
     }
 
-    if (res >= 0)
+    if (res >= 0 && i2cDev::verbose)
     {
         log<level::DEBUG>(ss.str().c_str());
     }
-    else
+    else if (res < 0)
     {
         log<level::ERR>(ss.str().c_str());
     }

--- a/src/common_i2c.hpp
+++ b/src/common_i2c.hpp
@@ -77,6 +77,7 @@ class i2cDev
     }
 
     static constexpr int i2cBlockSize = I2C_SMBUS_BLOCK_MAX;
+    static bool verbose;
 
   private:
     int devFD;

--- a/src/common_i2c.hpp
+++ b/src/common_i2c.hpp
@@ -66,9 +66,14 @@ class i2cDev
     int i2c_transfer(uint8_t tx_len, uint8_t* tx_data, uint8_t rx_len,
                      uint8_t* rx_data);
 
-    std::string getDevLabel()
+    std::string getDevLabel() const
     {
         return deviceLabel;
+    }
+
+    int getAddr() const
+    {
+        return i2cAddr;
     }
 
     static constexpr int i2cBlockSize = I2C_SMBUS_BLOCK_MAX;


### PR DESCRIPTION
storage: the yadro-storage-manager service spams many error and debug messages. This commit excludes a spam of error messages. And appends option '--verbose' for disable debug messages.

Signed-off-by: Evgeniy Kislenok e.kislenok@yadro.com
End-user-impact: none