### PR TITLE
mcu-updater: refix force-erase flag handling

### DIFF
--- a/src/mcu/updater.cpp
+++ b/src/mcu/updater.cpp
@@ -229,7 +229,7 @@ int main(int argc, char* argv[])
                                   // --- end of array ---
                                   {nullptr, 0, nullptr, '\0'}};
     int c;
-    while ((c = getopt_long(argc, argv, "f:b:a:v:eph", opts, nullptr)) != -1)
+    while ((c = getopt_long(argc, argv, "f:b:a:v:Eph", opts, nullptr)) != -1)
     {
         switch (c)
         {


### PR DESCRIPTION
This refixes 511a6fb064e3911749e709ac45e0493405b46dca and fix `--force-erase` flag handling.

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>